### PR TITLE
Fix unsupported registry entry class type error

### DIFF
--- a/efidevp.c
+++ b/efidevp.c
@@ -936,10 +936,11 @@ io_iterator_t RecursiveFindDevicePath(io_iterator_t iterator, const io_string_t 
 				}				
 				else
 				{
-					status = IOObjectGetClass(previous, class);
-					assertion(status == KERN_SUCCESS, "can't obtain class name");				
-					fprintf(stderr, "error: unsupported registry entry class type '%s'.\n",class);
-					exit(1);					
+					//status = IOObjectGetClass(previous, class);
+					//assertion(status == KERN_SUCCESS, "can't obtain class name");
+					//fprintf(stderr, "error: unsupported registry entry class type '%s'.\n",class);
+					//exit(1);
+					continue;
 				}
 				
 				if(DeviceNode != NULL)


### PR DESCRIPTION
Some PCI entries in IORegistry require several recursive calls before IOACPIPlatformDevice / IOPCIDevice entries will be found.

Before fix:
`./gfxutil -f PEGP`
`error: unsupported registry entry class type 'IORegistryEntry'.`
After fix:
`./gfxutil -f PEGP`
`DevicePath = PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)`