### PR TITLE
Fix unsupported registry entry class type error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 gfxutil changelog
 =================
+#### 1.79b
+- Fix unsupported registry entry class type error
+
 #### 1.78b
 - Unified release archive names
 

--- a/efidevp.c
+++ b/efidevp.c
@@ -935,13 +935,7 @@ io_iterator_t RecursiveFindDevicePath(io_iterator_t iterator, const io_string_t 
 					IOObjectRelease((unsigned int)location);
 				}				
 				else
-				{
-					//status = IOObjectGetClass(previous, class);
-					//assertion(status == KERN_SUCCESS, "can't obtain class name");
-					//fprintf(stderr, "error: unsupported registry entry class type '%s'.\n",class);
-					//exit(1);
 					continue;
-				}
 				
 				if(DeviceNode != NULL)
 				{

--- a/efidevp.c
+++ b/efidevp.c
@@ -936,10 +936,11 @@ io_iterator_t RecursiveFindDevicePath(io_iterator_t iterator, const io_string_t 
 				}				
 				else
 				{
-					status = IOObjectGetClass(previous, class);
-					assertion(status == KERN_SUCCESS, "can't obtain class name");				
-					fprintf(stderr, "error: unsupported registry entry class type '%s'.\n",class);
-					exit(1);					
+					//status = IOObjectGetClass(previous, class);
+					//assertion(status == KERN_SUCCESS, "can't obtain class name");
+					//fprintf(stderr, "error: unsupported registry entry class type '%s'.\n",class);
+					//exit(1);
+					continue;
 				}
 				
 				if(DeviceNode != NULL)

--- a/main.h
+++ b/main.h
@@ -9,7 +9,7 @@
 
 // Constants
 #define MAX_FILENAME 255
-#define VERSION "0.76b"
+#define VERSION "1.79b"
 
 const unsigned char _HexTabLC[16]= "0123456789abcdef";
 const unsigned char _HexTabUC[16]= "0123456789ABCDEF";


### PR DESCRIPTION
Some PCI devices in IODeviceTree have multiple entries that are not of the class type IOPCIDevice (eg. IORegistryEntry) so the RecursiveFindDevicePath will fail and exit. Adding a continue instead will recursively search out the IOPCIDevice entry and thus find the correct DevicePath.
Before Fix:
`./gfxutil -f PEGP`
`error: unsupported registry entry class type 'IORegistryEntry'.`
<img width="283" alt="PEGP0" src="https://user-images.githubusercontent.com/1698401/62986214-4d1b9f00-bdef-11e9-92e5-e1bf31872148.png">
After Fix:
`./gfxutil -f PEGP`
`DevicePath = PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)`
<img width="399" alt="PEGP1" src="https://user-images.githubusercontent.com/1698401/62986222-5b69bb00-bdef-11e9-9428-96ba2292ef81.png">