### PR TITLE
Add guard against badly formed vendor paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           cd gfxutil; src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
 
-      - run: cd gfxutil; xcodebuild -jobs 1 -configuration Debug
-      - run: cd gfxutil; xcodebuild -jobs 1 -configuration Release
+      - run: cd gfxutil; xcodebuild -project gfxutil.xcodeproj -jobs 1 -configuration Debug
+      - run: cd gfxutil; xcodebuild -project gfxutil.xcodeproj -jobs 1 -configuration Release
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v2
@@ -63,8 +63,8 @@ jobs:
 #         run: |
 #           cd gfxutil; src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
 # 
-#       - run: cd gfxutil; xcodebuild analyze -quiet -scheme gfxutil -configuration Debug CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]
-#       - run: cd gfxutil; xcodebuild analyze -quiet -scheme gfxutil -configuration Release CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]
+#       - run: cd gfxutil; xcodebuild -project gfxutil.xcodeproj analyze -quiet -scheme gfxutil -configuration Debug CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]
+#       - run: cd gfxutil; xcodebuild -project gfxutil.xcodeproj analyze -quiet -scheme gfxutil -configuration Release CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]
 # 
 #   analyze-coverity:
 #     name: Analyze Coverity
@@ -90,4 +90,4 @@ jobs:
 #         env:
 #           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 #           COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
-#           COVERITY_BUILD_COMMAND: xcodebuild -configuration Release
+#           COVERITY_BUILD_COMMAND: xcodebuild -project gfxutil.xcodeproj -configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ DerivedData
 build
 xcuserdata
 project.xcworkspace
-
+*.mode1
+*.mode1v3
+*.pbxuser

--- a/ProcessorBind.h
+++ b/ProcessorBind.h
@@ -1,0 +1,29 @@
+/*
+ *  ProcessorBind.h
+ *  gfxutil
+ *
+ *  Created by joevt on 21-12-21.
+ *
+ */
+
+#ifndef __GFXUTIL_PROCESSORBIND_H__
+#define __GFXUTIL_PROCESSORBIND_H__
+
+#ifdef MDE_CPU_EBC
+#elif defined(_MSC_EXTENSIONS)
+#else
+	#ifndef _Static_assert
+		#define CONCAT_IMPL(x,y) x##y
+		#define MACRO_CONCAT(x,y) CONCAT_IMPL(x,y)
+		#define _Static_assert(COND,MSG) \
+			typedef int MACRO_CONCAT( static_assertion, __LINE__ ) [(COND)?1:-1]
+	#endif
+#endif
+
+#if __LP64__
+	#include <../edk2/MdePkg/Include/X64/ProcessorBind.h>
+#else
+	#include <../edk2/MdePkg/Include/Ia32/ProcessorBind.h>
+#endif
+
+#endif

--- a/edk2.overrides
+++ b/edk2.overrides
@@ -4,8 +4,8 @@
 # See https://perldoc.perl.org/perlre
 
 while (<>) {
-	s/^(IsDevicePathEndType|DevPathToTextSasEx|DevPathFromTextSasEx)/Old\1/m;
-	s/^((\s*VOID\s+)Old(DevPathToTextSasEx.*?\)))/\2\3;\n\n\1/ms;
-	s/^((\s*EFI_DEVICE_PATH_PROTOCOL\s*\*\s+)Old(DevPathFromTextSasEx.*?\)))/\2\3;\n\n\1/ms;
+	s/^(IsDevicePathEndType|DevPathToTextSasEx|DevPathFromTextSasEx|DevPathToTextVendor|ConvertFromTextVendor)/Old\1/mg;
+	s/^((\s*VOID\s+)Old((DevPathToTextSasEx|DevPathToTextVendor).*?\)))/\2\3;\n\n\1/msg;
+	s/^((\s*EFI_DEVICE_PATH_PROTOCOL\s*\*\s+)Old((DevPathFromTextSasEx|ConvertFromTextVendor).*?\)))/\2\3;\n\n\1/msg;
 	print $_;
 }

--- a/edk2misc.c
+++ b/edk2misc.c
@@ -383,7 +383,7 @@ DevPathToTextEndInstance (
 );
 
 
-#define psize(x) sizeof(((EFI_DEV_PATH *)0)->x)
+#define psize(x) ((int)sizeof(((EFI_DEV_PATH *)0)->x))
 
 typedef struct {
 	UINT8 Type;
@@ -408,14 +408,14 @@ const DEVICE_NODE_TO_SIZE NodeSize[] = {
 	{MESSAGING_DEVICE_PATH , MSG_SCSI_DP                      , psize(Scsi)                      , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_FIBRECHANNEL_DP              , psize(FibreChannel)              , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_FIBRECHANNELEX_DP            , psize(FibreChannelEx)            , 0, 0 },
-	{MESSAGING_DEVICE_PATH , MSG_SASEX_DP                     , sizeof(PATCHED_SASEX_DEVICE_PATH), psize(SasEx), psize(SasEx) - sizeof(PATCHED_SASEX_DEVICE_PATH) }, // Patched to support both sizes
+	{MESSAGING_DEVICE_PATH , MSG_SASEX_DP                     , (int)sizeof(PATCHED_SASEX_DEVICE_PATH), psize(SasEx), psize(SasEx) - (int)sizeof(PATCHED_SASEX_DEVICE_PATH) }, // Patched to support both sizes
 	{MESSAGING_DEVICE_PATH , MSG_NVME_NAMESPACE_DP            , psize(NvmeNamespace)             , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_UFS_DP                       , psize(Ufs)                       , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_SD_DP                        , psize(Sd)                        , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_EMMC_DP                      , psize(Emmc)                      , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_1394_DP                      , psize(F1394)                     , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_USB_DP                       , psize(Usb)                       , 0, 0 },
-	{MESSAGING_DEVICE_PATH , MSG_USB_WWID_DP                  , psize(UsbWwid) + sizeof(CHAR16)  , 1, sizeof(CHAR16) }, // bug exists with zero length string, so add CHAR(16) for minimum
+	{MESSAGING_DEVICE_PATH , MSG_USB_WWID_DP                  , (int)psize(UsbWwid) + (int)sizeof(CHAR16)  , 1, (int)sizeof(CHAR16) }, // bug exists with zero length string, so add CHAR(16) for minimum
 	{MESSAGING_DEVICE_PATH , MSG_DEVICE_LOGICAL_UNIT_DP       , psize(LogicUnit)                 , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_USB_CLASS_DP                 , psize(UsbClass)                  , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_SATA_DP                      , psize(Sata)                      , 0, 0 },
@@ -432,7 +432,7 @@ const DEVICE_NODE_TO_SIZE NodeSize[] = {
 	{MESSAGING_DEVICE_PATH , MSG_URI_DP                       , psize(Uri)                       , 1, psize(Uri.Uri[0]) },
 	{MESSAGING_DEVICE_PATH , MSG_BLUETOOTH_DP                 , psize(Bluetooth)                 , 0, 0 },
 	{MESSAGING_DEVICE_PATH , MSG_WIFI_DP                      , psize(WiFi)                      , 0, 0 },
-	{MESSAGING_DEVICE_PATH , MSG_BLUETOOTH_LE_DP              , sizeof(BLUETOOTH_LE_DEVICE_PATH) , 0, 0 },
+	{MESSAGING_DEVICE_PATH , MSG_BLUETOOTH_LE_DP              , (int)sizeof(BLUETOOTH_LE_DEVICE_PATH) , 0, 0 },
 	{MEDIA_DEVICE_PATH     , MEDIA_HARDDRIVE_DP               , psize(HardDrive)                 , 0, 0 },
 	{MEDIA_DEVICE_PATH     , MEDIA_CDROM_DP                   , psize(CD)                        , 0, 0 },
 	{MEDIA_DEVICE_PATH     , MEDIA_VENDOR_DP                  , psize(Vendor)                    , 1, 1 },

--- a/efidevp.c
+++ b/efidevp.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 
@@ -264,9 +265,9 @@ void GetPaths(io_service_t device, char *ioregPath, char **efiPath, SETTINGS *se
 				uint32_t size;
 				uid[0] = '\0';
 				pnp[0] = '\0';
-				size = sizeof(uid); IORegistryEntryGetProperty(device, "_UID", uid, &size);
-				size = sizeof(pnp); if (IORegistryEntryGetProperty(device, "compatible", pnp, &size)) {
-					size = sizeof(pnp); IORegistryEntryGetProperty(device, "name", pnp, &size);
+				size = (uint32_t)sizeof(uid); IORegistryEntryGetProperty(device, "_UID", uid, &size);
+				size = (uint32_t)sizeof(pnp); if (IORegistryEntryGetProperty(device, "compatible", pnp, &size)) {
+					size = (uint32_t)sizeof(pnp); IORegistryEntryGetProperty(device, "name", pnp, &size);
 				}
 				AsciiStrToUnicodeStrS(pnp, pnp16, ARRAY_SIZE(pnp16));
 				ACPI_HID_DEVICE_PATH *Acpi = (ACPI_HID_DEVICE_PATH *) CreateDeviceNode (ACPI_DEVICE_PATH, ACPI_DP, sizeof(ACPI_HID_DEVICE_PATH));
@@ -328,7 +329,7 @@ void OutputOneDevice(io_service_t device, SETTINGS *settings)
 		{
 			doit = false;
 			io_string_t name;
-			unsigned int size = 0;
+			uint32_t size = 0;
 			io_struct_inband_t prop_name;
 			io_struct_inband_t prop_ioname;
 			kern_return_t status;
@@ -336,10 +337,10 @@ void OutputOneDevice(io_service_t device, SETTINGS *settings)
 			status = IORegistryEntryGetNameInPlane(device, settings->plane, name);
 			assertion(status == KERN_SUCCESS, "can't obtain registry entry name");
 			
-			size = sizeof(prop_name);
+			size = (uint32_t)sizeof(prop_name);
 			IORegistryEntryGetProperty(device, "name", prop_name, &size);
 
-			size = sizeof(prop_ioname);
+			size = (uint32_t)sizeof(prop_ioname);
 			IORegistryEntryGetProperty(device, "IOName", prop_ioname, &size);
 					
 			if (!strcasecmp(prop_name, settings->search) || !strcasecmp(prop_ioname, settings->search) || !strcasecmp(name, settings->search))
@@ -356,7 +357,7 @@ void OutputOneDevice(io_service_t device, SETTINGS *settings)
 		{
 			ioregPath[0] = '\0';
 
-			size = sizeof(temp);
+			size = (uint32_t)sizeof(temp);
 			kr = IORegistryEntryGetProperty(device, "pcidebug", temp, &size);
 			if (kr == KERN_SUCCESS)
 			{
@@ -367,11 +368,11 @@ void OutputOneDevice(io_service_t device, SETTINGS *settings)
 				printf("        ");
 			}
 
-			size = sizeof(vendor_id);
+			size = (uint32_t)sizeof(vendor_id);
 			kr = IORegistryEntryGetProperty(device, "vendor-id", (char*)&vendor_id, &size);
 			if (kr == KERN_SUCCESS)
 			{
-				size = sizeof(device_id);
+				size = (uint32_t)sizeof(device_id);
 				kr = IORegistryEntryGetProperty(device, "device-id", (char*)&device_id, &size);
 			}
 			if (kr == KERN_SUCCESS)

--- a/efidevp.c
+++ b/efidevp.c
@@ -348,10 +348,6 @@ void OutputOneDevice(io_service_t device, SETTINGS *settings)
 				settings->matched = true;
 				doit = true;
 			}
-
-			IOObjectRelease((unsigned int)prop_name);
-			IOObjectRelease((unsigned int)prop_ioname);
-			IOObjectRelease((unsigned int)name);
 		}
 		if (doit)
 		{

--- a/gfxutil xcode 3.2.1 10.6 i386 x86_64.xcodeproj/project.pbxproj
+++ b/gfxutil xcode 3.2.1 10.6 i386 x86_64.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 44;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -37,11 +37,11 @@
 		6374FFFF266ACF1800ABDA7F /* String.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5A523A56E5400AE5FF7 /* String.c */; };
 		6377A5DB23A572B000AE5FF7 /* edk2misc.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5DA23A572B000AE5FF7 /* edk2misc.c */; };
 		63C2792C23B32CAA008C348C /* efidevp.c in Sources */ = {isa = PBXBuildFile; fileRef = 63C2792B23B32CAA008C348C /* efidevp.c */; };
+		63DE4B89276DEB500095F0CE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63DE4B88276DEB500095F0CE /* IOKit.framework */; };
+		63DE4C3B276DEB660095F0CE /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63DE4C3A276DEB660095F0CE /* CoreFoundation.framework */; };
 		8DD76F770486A8DE00D96B5E /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* main.c */; settings = {ATTRIBUTES = (); }; };
 		8DD76F7C0486A8DE00D96B5E /* gfxutil.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859E970290921104C91782 /* gfxutil.1 */; };
 		9813AB380D12A271001DF28C /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9813AB360D12A271001DF28C /* utils.c */; };
-		CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8120FE90F000ED7DC0 /* IOKit.framework */; };
-		CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -50,10 +50,6 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*/edk2/*.c";
 			fileType = pattern.proxy;
-			inputFiles = (
-				"$(SRCROOT)/edk2.overrides",
-				"$(INPUT_FILE_PATH)",
-			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_SOURCES_DIR)/$(INPUT_FILE_BASE).c",
@@ -77,6 +73,7 @@
 
 /* Begin PBXFileReference section */
 		08FB7796FE84155DC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		6371D7BE2772341300AE09E0 /* ProcessorBind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessorBind.h; sourceTree = "<group>"; };
 		6374005B266AE30600ABDA7F /* edk2.overrides */ = {isa = PBXFileReference; lastKnownFileType = text; path = edk2.overrides; sourceTree = "<group>"; };
 		6377A5A323A56E5300AE5FF7 /* DivU64x32Remainder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = DivU64x32Remainder.c; path = ../edk2/MdePkg/Library/BaseLib/DivU64x32Remainder.c; sourceTree = "<group>"; };
 		6377A5A423A56E5400AE5FF7 /* MultU64x32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = MultU64x32.c; path = ../edk2/MdePkg/Library/BaseLib/MultU64x32.c; sourceTree = "<group>"; };
@@ -112,15 +109,15 @@
 		63C2792B23B32CAA008C348C /* efidevp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = efidevp.c; sourceTree = "<group>"; };
 		63C2792D23B33648008C348C /* DevicePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DevicePath.h; path = ../edk2/MdePkg/Include/Protocol/DevicePath.h; sourceTree = "<group>"; };
 		63C2792E23B37170008C348C /* UefiDevicePathLib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UefiDevicePathLib.h; path = ../edk2/MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.h; sourceTree = "<group>"; };
+		63DE4B88276DEB500095F0CE /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		63DE4C3A276DEB660095F0CE /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		8DD76F7E0486A8DE00D96B5E /* gfxutil */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gfxutil; sourceTree = BUILT_PRODUCTS_DIR; };
 		9813AB360D12A271001DF28C /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
 		9813AB370D12A271001DF28C /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		98CAD3FE0D3381B500808BB2 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
 		C6859E970290921104C91782 /* gfxutil.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = gfxutil.1; sourceTree = "<group>"; };
-		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
-		CE363A8120FE90F000ED7DC0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
-		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = Changelog.md; sourceTree = "<group>"; };
+		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,8 +125,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */,
-				CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */,
+				63DE4B89276DEB500095F0CE /* IOKit.framework in Frameworks */,
+				63DE4C3B276DEB660095F0CE /* CoreFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,6 +157,7 @@
 				08FB7796FE84155DC02AAC07 /* main.c */,
 				98CAD3FE0D3381B500808BB2 /* main.h */,
 				6374005B266AE30600ABDA7F /* edk2.overrides */,
+				6371D7BE2772341300AE09E0 /* ProcessorBind.h */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -222,8 +220,8 @@
 		CE363A8020FE90F000ED7DC0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */,
-				CE363A8120FE90F000ED7DC0 /* IOKit.framework */,
+				63DE4C3A276DEB660095F0CE /* CoreFoundation.framework */,
+				63DE4B88276DEB500095F0CE /* IOKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -259,7 +257,7 @@
 			attributes = {
 				LastUpgradeCheck = 1250;
 			};
-			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */;
+			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil xcode 3.2.1 10.6 i386 x86_64" */;
 			compatibilityVersion = "Xcode 3.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
@@ -282,18 +280,14 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 			);
 			name = Archive;
-			outputFileListPaths = (
-			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\ndist=(\"$FULL_PRODUCT_NAME\")\nif [ -d \"$DWARF_DSYM_FILE_NAME\" ]; then dist+=(\"$DWARF_DSYM_FILE_NAME\"); fi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry -FS \"${archive}\" \"${dist[@]}\"\n";
+			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\necho \"••••••••••\" \"$DWARF_DSYM_FILE_NAME\"\ndist=(\"$FULL_PRODUCT_NAME\")\nif [[ -d $DWARF_DSYM_FILE_NAME ]]; then\n\tdist=(${dist[@]} \"$DWARF_DSYM_FILE_NAME\")\nfi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry \"${archive}\" \"${dist[@]}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -343,25 +337,18 @@
 		1DEB924808733DCA0010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
+				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.81b;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
-				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_VERSION = 4.0;
+				GCC_WARN_UNINITIALIZED_AUTOS = NO;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -369,37 +356,33 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
-				ZERO_LINK = YES;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.6.sdk";
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Debug;
 		};
 		1DEB924908733DCA0010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
+				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
 				CURRENT_PROJECT_VERSION = 1.81b;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_MODEL_TUNING = G5;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
-				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_VERSION = 4.0;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -407,13 +390,18 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.6.sdk";
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Release;
 		};
@@ -421,30 +409,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
+				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -452,9 +418,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.4u.sdk";
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
@@ -463,29 +429,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
+				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -493,9 +438,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.4u.sdk";
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
@@ -512,7 +457,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */ = {
+		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil xcode 3.2.1 10.6 i386 x86_64" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB924C08733DCA0010E9CD /* Debug */,

--- a/gfxutil xcode 3.2.1 10.6 i386 x86_64.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
+++ b/gfxutil xcode 3.2.1 10.6 i386 x86_64.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+               BuildableName = "gfxutil"
+               BlueprintName = "gfxutil"
+               ReferencedContainer = "container:gfxutil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      enableUBSanitizer = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "02010c00d041030a0000000001010600001b0101060000000316100001000000000000000000000004012a0002000000062c0100000000004d7d000100000000e7f9c0ca664da545b0bd10a52e34ec5d020204032400f7fc74be7c0bf349914701f4042e68426c5c2fe7555cc34aaabf0209eb2185077fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "04061400CA98B835A9B6CE498C72904735CC49B7FFFF04007074616C380000000000000000000000000000000000000000000000000000000000000000000000"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-vsn -o xml -i bin deviceproperties.bin deviceproperties.plist"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "PciRoot(0x0)/Pci(0x1B,0x0)/Pci(0x0,0x0)/SasEx(0x01,0x0,0x0,NoTopology,0,0,0)/MediaPath(1,02000000062C0100000000004D7D000100000000E7F9C0CA664DA545B0BD10A52E34EC5D0202)/MediaPath(3,F7FC74BE7C0BF349914701F4042E68426C5C2FE7555CC34AAABF0209EB218507)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030a2c001b619942c94cdf43882b2a0707a4a95f53dacd73f295b442bc876e5f0d2c535b002291a83e9d01000101060000010101060000007fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030A0500017FFF0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "VenMsg(00000000-0000-0000-0000-000000000000,0110)"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/gfxutil.xcodeproj/project.pbxproj
+++ b/gfxutil.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 			outputFiles = (
 				"$(DERIVED_SOURCES_DIR)/$(INPUT_FILE_BASE).c",
 			);
+			runOncePerArchitecture = 0;
 			script = "perl -0777 edk2.overrides \"${INPUT_FILE_PATH}\" > \"${DERIVED_SOURCES_DIR}/${INPUT_FILE_BASE}.c\"\n";
 		};
 /* End PBXBuildRule section */
@@ -348,7 +349,6 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.81b;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
 				OTHER_CFLAGS = (
@@ -376,7 +376,6 @@
 					../edk2/MdePkg/Library/BaseLib,
 					../edk2/MdePkg/Library/BasePrintLib,
 				);
-				ZERO_LINK = YES;
 			};
 			name = Debug;
 		};
@@ -387,7 +386,6 @@
 				CODE_SIGN_IDENTITY = "-";
 				CURRENT_PROJECT_VERSION = 1.81b;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;
 				OTHER_CFLAGS = (
 					"-fshort-wchar",
@@ -421,10 +419,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -455,7 +449,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -463,10 +456,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -494,9 +483,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};

--- a/gfxutil.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
+++ b/gfxutil.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
@@ -65,11 +65,11 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "02010c00d041030a0000000001010600001b0101060000000316100001000000000000000000000004012a0002000000062c0100000000004d7d000100000000e7f9c0ca664da545b0bd10a52e34ec5d020204032400f7fc74be7c0bf349914701f4042e68426c5c2fe7555cc34aaabf0209eb2185077fff0400"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "04061400CA98B835A9B6CE498C72904735CC49B7FFFF04007074616C380000000000000000000000000000000000000000000000000000000000000000000000"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-vsn -o xml -i bin deviceproperties.bin deviceproperties.plist"
@@ -82,6 +82,14 @@
          <CommandLineArgument
             argument = "030a2c001b619942c94cdf43882b2a0707a4a95f53dacd73f295b442bc876e5f0d2c535b002291a83e9d01000101060000010101060000007fff0400"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030A0500017FFF0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "VenMsg(00000000-0000-0000-0000-000000000000,0110)"
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/gfxutil_xcode 2.5 10.4 i386.xcodeproj/project.pbxproj
+++ b/gfxutil_xcode 2.5 10.4 i386.xcodeproj/project.pbxproj
@@ -3,10 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 42;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6318D925276DBF4300F05627 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6318D924276DBF4300F05627 /* IOKit.framework */; };
+		6318D9C6276DBF6300F05627 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6318D9C5276DBF6300F05627 /* CoreFoundation.framework */; };
 		63740000266ACF1800ABDA7F /* DevicePathToText.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5B323A56E5500AE5FF7 /* DevicePathToText.c */; };
 		63740001266ACF1800ABDA7F /* PrintLibInternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5BD23A56E5500AE5FF7 /* PrintLibInternal.c */; };
 		63740002266ACF1800ABDA7F /* SwapBytes16.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5AB23A56E5400AE5FF7 /* SwapBytes16.c */; };
@@ -40,8 +42,6 @@
 		8DD76F770486A8DE00D96B5E /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* main.c */; settings = {ATTRIBUTES = (); }; };
 		8DD76F7C0486A8DE00D96B5E /* gfxutil.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859E970290921104C91782 /* gfxutil.1 */; };
 		9813AB380D12A271001DF28C /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9813AB360D12A271001DF28C /* utils.c */; };
-		CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8120FE90F000ED7DC0 /* IOKit.framework */; };
-		CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -50,10 +50,6 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*/edk2/*.c";
 			fileType = pattern.proxy;
-			inputFiles = (
-				"$(SRCROOT)/edk2.overrides",
-				"$(INPUT_FILE_PATH)",
-			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_SOURCES_DIR)/$(INPUT_FILE_BASE).c",
@@ -77,6 +73,8 @@
 
 /* Begin PBXFileReference section */
 		08FB7796FE84155DC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		6318D924276DBF4300F05627 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = SDKs/MacOSX10.4u.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
+		6318D9C5276DBF6300F05627 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = SDKs/MacOSX10.4u.sdk/System/Library/Frameworks/CoreFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		6374005B266AE30600ABDA7F /* edk2.overrides */ = {isa = PBXFileReference; lastKnownFileType = text; path = edk2.overrides; sourceTree = "<group>"; };
 		6377A5A323A56E5300AE5FF7 /* DivU64x32Remainder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = DivU64x32Remainder.c; path = ../edk2/MdePkg/Library/BaseLib/DivU64x32Remainder.c; sourceTree = "<group>"; };
 		6377A5A423A56E5400AE5FF7 /* MultU64x32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = MultU64x32.c; path = ../edk2/MdePkg/Library/BaseLib/MultU64x32.c; sourceTree = "<group>"; };
@@ -112,15 +110,13 @@
 		63C2792B23B32CAA008C348C /* efidevp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = efidevp.c; sourceTree = "<group>"; };
 		63C2792D23B33648008C348C /* DevicePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DevicePath.h; path = ../edk2/MdePkg/Include/Protocol/DevicePath.h; sourceTree = "<group>"; };
 		63C2792E23B37170008C348C /* UefiDevicePathLib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UefiDevicePathLib.h; path = ../edk2/MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.h; sourceTree = "<group>"; };
-		8DD76F7E0486A8DE00D96B5E /* gfxutil */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gfxutil; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DD76F7E0486A8DE00D96B5E /* gfxutil */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.executable"; path = gfxutil; sourceTree = BUILT_PRODUCTS_DIR; };
 		9813AB360D12A271001DF28C /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
 		9813AB370D12A271001DF28C /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		98CAD3FE0D3381B500808BB2 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
 		C6859E970290921104C91782 /* gfxutil.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = gfxutil.1; sourceTree = "<group>"; };
-		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
-		CE363A8120FE90F000ED7DC0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
-		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = Changelog.md; sourceTree = "<group>"; };
+		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,8 +124,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */,
-				CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */,
+				6318D925276DBF4300F05627 /* IOKit.framework in Frameworks */,
+				6318D9C6276DBF6300F05627 /* CoreFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,8 +218,8 @@
 		CE363A8020FE90F000ED7DC0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */,
-				CE363A8120FE90F000ED7DC0 /* IOKit.framework */,
+				6318D924276DBF4300F05627 /* IOKit.framework */,
+				6318D9C5276DBF6300F05627 /* CoreFoundation.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -259,7 +255,7 @@
 			attributes = {
 				LastUpgradeCheck = 1250;
 			};
-			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */;
+			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil_xcode 2.5 10.4 i386" */;
 			compatibilityVersion = "Xcode 3.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
@@ -282,18 +278,14 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 			);
 			name = Archive;
-			outputFileListPaths = (
-			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\ndist=(\"$FULL_PRODUCT_NAME\")\nif [ -d \"$DWARF_DSYM_FILE_NAME\" ]; then dist+=(\"$DWARF_DSYM_FILE_NAME\"); fi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry -FS \"${archive}\" \"${dist[@]}\"\n";
+			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\necho \"••••••••••\" \"$DWARF_DSYM_FILE_NAME\"\ndist=(\"$FULL_PRODUCT_NAME\")\nif [[ -d $DWARF_DSYM_FILE_NAME ]]; then\n\tdist=(${dist[@]} \"$DWARF_DSYM_FILE_NAME\")\nfi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry \"${archive}\" \"${dist[@]}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -343,25 +335,18 @@
 		1DEB924808733DCA0010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.81b;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
-				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_WARN_UNINITIALIZED_AUTOS = NO;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -369,37 +354,32 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
-				ZERO_LINK = YES;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Debug;
 		};
 		1DEB924908733DCA0010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
 				CURRENT_PROJECT_VERSION = 1.81b;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_MODEL_TUNING = G5;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
 				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_MODEL_TUNING = G5;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -407,13 +387,17 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Release;
 		};
@@ -421,41 +405,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
+				ARCHS = i386;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Debug;
 		};
@@ -463,40 +420,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ARCHS = i386;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Release;
 		};
@@ -512,7 +443,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */ = {
+		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil_xcode 2.5 10.4 i386" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB924C08733DCA0010E9CD /* Debug */,

--- a/gfxutil_xcode 2.5 10.4 i386.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
+++ b/gfxutil_xcode 2.5 10.4 i386.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+               BuildableName = "gfxutil"
+               BlueprintName = "gfxutil"
+               ReferencedContainer = "container:gfxutil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      enableUBSanitizer = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "02010c00d041030a0000000001010600001b0101060000000316100001000000000000000000000004012a0002000000062c0100000000004d7d000100000000e7f9c0ca664da545b0bd10a52e34ec5d020204032400f7fc74be7c0bf349914701f4042e68426c5c2fe7555cc34aaabf0209eb2185077fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "04061400CA98B835A9B6CE498C72904735CC49B7FFFF04007074616C380000000000000000000000000000000000000000000000000000000000000000000000"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-vsn -o xml -i bin deviceproperties.bin deviceproperties.plist"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "PciRoot(0x0)/Pci(0x1B,0x0)/Pci(0x0,0x0)/SasEx(0x01,0x0,0x0,NoTopology,0,0,0)/MediaPath(1,02000000062C0100000000004D7D000100000000E7F9C0CA664DA545B0BD10A52E34EC5D0202)/MediaPath(3,F7FC74BE7C0BF349914701F4042E68426C5C2FE7555CC34AAABF0209EB218507)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030a2c001b619942c94cdf43882b2a0707a4a95f53dacd73f295b442bc876e5f0d2c535b002291a83e9d01000101060000010101060000007fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030A0500017FFF0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "VenMsg(00000000-0000-0000-0000-000000000000,0110)"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/gfxutil_xcode 3.1.3 10.5 i386.xcodeproj/project.pbxproj
+++ b/gfxutil_xcode 3.1.3 10.5 i386.xcodeproj/project.pbxproj
@@ -3,10 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 44;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6318D925276DBF4300F05627 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6318D924276DBF4300F05627 /* IOKit.framework */; };
+		6318D9C6276DBF6300F05627 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6318D9C5276DBF6300F05627 /* CoreFoundation.framework */; };
 		63740000266ACF1800ABDA7F /* DevicePathToText.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5B323A56E5500AE5FF7 /* DevicePathToText.c */; };
 		63740001266ACF1800ABDA7F /* PrintLibInternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5BD23A56E5500AE5FF7 /* PrintLibInternal.c */; };
 		63740002266ACF1800ABDA7F /* SwapBytes16.c in Sources */ = {isa = PBXBuildFile; fileRef = 6377A5AB23A56E5400AE5FF7 /* SwapBytes16.c */; };
@@ -40,8 +42,6 @@
 		8DD76F770486A8DE00D96B5E /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* main.c */; settings = {ATTRIBUTES = (); }; };
 		8DD76F7C0486A8DE00D96B5E /* gfxutil.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859E970290921104C91782 /* gfxutil.1 */; };
 		9813AB380D12A271001DF28C /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9813AB360D12A271001DF28C /* utils.c */; };
-		CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8120FE90F000ED7DC0 /* IOKit.framework */; };
-		CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -50,10 +50,6 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*/edk2/*.c";
 			fileType = pattern.proxy;
-			inputFiles = (
-				"$(SRCROOT)/edk2.overrides",
-				"$(INPUT_FILE_PATH)",
-			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_SOURCES_DIR)/$(INPUT_FILE_BASE).c",
@@ -77,6 +73,8 @@
 
 /* Begin PBXFileReference section */
 		08FB7796FE84155DC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		6318D924276DBF4300F05627 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = SDKs/MacOSX10.4u.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
+		6318D9C5276DBF6300F05627 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = SDKs/MacOSX10.4u.sdk/System/Library/Frameworks/CoreFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		6374005B266AE30600ABDA7F /* edk2.overrides */ = {isa = PBXFileReference; lastKnownFileType = text; path = edk2.overrides; sourceTree = "<group>"; };
 		6377A5A323A56E5300AE5FF7 /* DivU64x32Remainder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = DivU64x32Remainder.c; path = ../edk2/MdePkg/Library/BaseLib/DivU64x32Remainder.c; sourceTree = "<group>"; };
 		6377A5A423A56E5400AE5FF7 /* MultU64x32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = MultU64x32.c; path = ../edk2/MdePkg/Library/BaseLib/MultU64x32.c; sourceTree = "<group>"; };
@@ -117,10 +115,8 @@
 		9813AB370D12A271001DF28C /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		98CAD3FE0D3381B500808BB2 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
 		C6859E970290921104C91782 /* gfxutil.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = gfxutil.1; sourceTree = "<group>"; };
-		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
-		CE363A8120FE90F000ED7DC0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
-		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		CE147CCF2185E87400536AE6 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = Changelog.md; sourceTree = "<group>"; };
+		CEC0494720FEA1B300FBCAC9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,8 +124,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE363A8420FE90FC00ED7DC0 /* CoreFoundation.framework in Frameworks */,
-				CE363A8220FE90F000ED7DC0 /* IOKit.framework in Frameworks */,
+				6318D925276DBF4300F05627 /* IOKit.framework in Frameworks */,
+				6318D9C6276DBF6300F05627 /* CoreFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,8 +218,8 @@
 		CE363A8020FE90F000ED7DC0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CE363A8320FE90FC00ED7DC0 /* CoreFoundation.framework */,
-				CE363A8120FE90F000ED7DC0 /* IOKit.framework */,
+				6318D924276DBF4300F05627 /* IOKit.framework */,
+				6318D9C5276DBF6300F05627 /* CoreFoundation.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -259,7 +255,7 @@
 			attributes = {
 				LastUpgradeCheck = 1250;
 			};
-			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */;
+			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil_xcode 3.1.3 10.5 i386" */;
 			compatibilityVersion = "Xcode 3.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
@@ -282,18 +278,14 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 			);
 			name = Archive;
-			outputFileListPaths = (
-			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\ndist=(\"$FULL_PRODUCT_NAME\")\nif [ -d \"$DWARF_DSYM_FILE_NAME\" ]; then dist+=(\"$DWARF_DSYM_FILE_NAME\"); fi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry -FS \"${archive}\" \"${dist[@]}\"\n";
+			shellScript = "cd \"${TARGET_BUILD_DIR}\"\n\necho \"••••••••••\" \"$DWARF_DSYM_FILE_NAME\"\ndist=(\"$FULL_PRODUCT_NAME\")\nif [[ -d $DWARF_DSYM_FILE_NAME ]]; then\n\tdist=(${dist[@]} \"$DWARF_DSYM_FILE_NAME\")\nfi\n\narchive=\"${PRODUCT_NAME}-${CURRENT_PROJECT_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\nstrip -x -T \"${EXECUTABLE_PATH}\" &>/dev/null || strip -x \"${EXECUTABLE_PATH}\"\nfi\nzip -qry \"${archive}\" \"${dist[@]}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -343,25 +335,18 @@
 		1DEB924808733DCA0010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.81b;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
-				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_WARN_UNINITIALIZED_AUTOS = NO;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -369,37 +354,33 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
-				ZERO_LINK = YES;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Debug;
 		};
 		1DEB924908733DCA0010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "-";
 				CURRENT_PROJECT_VERSION = 1.81b;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_MODEL_TUNING = G5;
-				INSTALL_PATH = /usr/local/bin;
-				OTHER_CFLAGS = (
-					"-fshort-wchar",
-					"-DNO_MSABI_VA_FUNCS",
-					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
-					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
-					"-fsanitize-blacklist=$(PROJECT_DIR)/sanblacklist.txt",
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
 				);
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = gfxutil;
-				SYSTEM_HEADER_SEARCH_PATHS = (
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_MODEL_TUNING = G5;
+				HEADER_SEARCH_PATHS = (
 					../edk2/MdePkg/Include,
 					../edk2/MdePkg/Library/UefiDevicePathLib,
 					../edk2/MdePkg/Library/UefiMemoryLib,
@@ -407,13 +388,18 @@
 					../edk2/MdePkg/Library/BasePrintLib,
 					.,
 				);
-				USER_HEADER_SEARCH_PATHS = (
-					../edk2/MdePkg/Include,
-					../edk2/MdePkg/Library/UefiDevicePathLib,
-					../edk2/MdePkg/Library/UefiMemoryLib,
-					../edk2/MdePkg/Library/BaseLib,
-					../edk2/MdePkg/Library/BasePrintLib,
+				INSTALL_PATH = /usr/local/bin;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-fshort-wchar",
+					"-DNO_MSABI_VA_FUNCS",
+					"-D_PCD_GET_MODE_32_PcdMaximumAsciiStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumUnicodeStringLength=0",
+					"-D_PCD_GET_MODE_32_PcdMaximumDevicePathNodeCount=0",
 				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = gfxutil;
+				USER_HEADER_SEARCH_PATHS = "../edk2/MdePkg/Include ../edk2/MdePkg/Library/UefiDevicePathLib ../edk2/MdePkg/Library/UefiMemoryLib ../edk2/MdePkg/Library/BaseLib ../edk2/MdePkg/Library/BasePrintLib";
 			};
 			name = Release;
 		};
@@ -421,40 +407,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
+				ARCHS = i386;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.4u.sdk";
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
@@ -463,39 +425,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					x86_64,
-					i386,
-				);
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ARCHS = i386;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.4u.sdk";
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
@@ -512,7 +451,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil" */ = {
+		1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "gfxutil_xcode 3.1.3 10.5 i386" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB924C08733DCA0010E9CD /* Debug */,

--- a/gfxutil_xcode 3.1.3 10.5 i386.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
+++ b/gfxutil_xcode 3.1.3 10.5 i386.xcodeproj/xcshareddata/xcschemes/gfxutil.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+               BuildableName = "gfxutil"
+               BlueprintName = "gfxutil"
+               ReferencedContainer = "container:gfxutil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      enableUBSanitizer = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "02010c00d041030a0000000001010600001b0101060000000316100001000000000000000000000004012a0002000000062c0100000000004d7d000100000000e7f9c0ca664da545b0bd10a52e34ec5d020204032400f7fc74be7c0bf349914701f4042e68426c5c2fe7555cc34aaabf0209eb2185077fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "04061400CA98B835A9B6CE498C72904735CC49B7FFFF04007074616C380000000000000000000000000000000000000000000000000000000000000000000000"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-vsn -o xml -i bin deviceproperties.bin deviceproperties.plist"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "PciRoot(0x0)/Pci(0x1B,0x0)/Pci(0x0,0x0)/SasEx(0x01,0x0,0x0,NoTopology,0,0,0)/MediaPath(1,02000000062C0100000000004D7D000100000000E7F9C0CA664DA545B0BD10A52E34EC5D0202)/MediaPath(3,F7FC74BE7C0BF349914701F4042E68426C5C2FE7555CC34AAABF0209EB218507)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030a2c001b619942c94cdf43882b2a0707a4a95f53dacd73f295b442bc876e5f0d2c535b002291a83e9d01000101060000010101060000007fff0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "030A0500017FFF0400"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "VenMsg(00000000-0000-0000-0000-000000000000,0110)"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "gfxutil"
+            BlueprintName = "gfxutil"
+            ReferencedContainer = "container:gfxutil.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/main.c
+++ b/main.c
@@ -532,13 +532,13 @@ GFX_HEADER *parse_binary(unsigned char * bp, unsigned char * bpend, SETTINGS *se
 			{			
 				switch(data_len)
 				{
-					case sizeof(UINT8): // int8
+					case (unsigned int)sizeof(UINT8): // int8
 						gfx_entry->val_type = DATA_INT8;
 					break;
-					case sizeof(UINT16): //int16
+					case (unsigned int)sizeof(UINT16): //int16
 						gfx_entry->val_type = DATA_INT16;
 					break;
-					case sizeof(UINT32): //int32
+					case (unsigned int)sizeof(UINT32): //int32
 						gfx_entry->val_type = DATA_INT32;
 					break;
 					default:
@@ -995,6 +995,12 @@ error:
 	return NULL;
 }
 
+#ifndef CFErrorRef
+	#define CFErrorRef CFStringRef
+	#define CFPropertyListCreateWithStream CFPropertyListCreateFromStream
+	#define CFPropertyListWrite(propertyList, stream, format, options, error)  CFPropertyListWriteToStream(propertyList, stream, format, error)
+#endif
+
 int WritePropertyList(CFPropertyListRef propertyList, CFURLRef fileURL)
 {
 	CFWriteStreamRef stream;
@@ -1198,7 +1204,7 @@ int parse_args(int argc, char * argv[], SETTINGS *settings)
 				if (device != MACH_PORT_NULL)
 				{
 					char buffer[4096] = {0};
-					uint32_t size = sizeof(buffer);
+					uint32_t size = (uint32_t)sizeof(buffer);
 					
 					kern_return_t kr = IORegistryEntryGetProperty(device, argv[optind], buffer, &size);
 					IOObjectRelease(device);

--- a/main.c
+++ b/main.c
@@ -1683,7 +1683,6 @@ int translate_properties (char * argv[], SETTINGS *settings)
 		break;
 		default:
 			fprintf(stderr, "%s: unknown input file type\n", argv[0]);
-			fclose(fp);
 			return(1);
 		break;
 	}

--- a/utils.c
+++ b/utils.c
@@ -362,7 +362,7 @@ unsigned int Xtoi (char *Str, unsigned int *Bytes)
 
   // convert hex digits
   u = 0;
-  Length = sizeof (unsigned int);
+  Length = (unsigned int)sizeof (unsigned int);
   HexStringToBuf ((unsigned char *) &u, &Length, Str, Bytes);
 
   return u;
@@ -374,7 +374,7 @@ void Xtoi64 (char *Str, unsigned long *Data, unsigned int *Bytes)
   unsigned int Length;
 
   *Data = 0;
-  Length = sizeof (unsigned long);
+  Length = (unsigned int)sizeof (unsigned long);
   HexStringToBuf ((unsigned char *) Data, &Length, Str, Bytes);
 }
 
@@ -464,7 +464,7 @@ int StrToBuf (unsigned char *Buf, unsigned int BufferLength, char *Str)
   unsigned char Byte;
 
   // Two hex char make up one byte
-  StrLength = BufferLength * sizeof (char);
+  StrLength = BufferLength * (unsigned int)sizeof (char);
 
   for(Index = 0; Index < StrLength; Index++, Str++) 
   {

--- a/utils.c
+++ b/utils.c
@@ -500,7 +500,7 @@ int HexStringToBuf (unsigned char *Buf, unsigned int *Len, char *Str, unsigned i
   unsigned int HexCnt;
   unsigned int Idx;
   unsigned int BufferLength;
-  unsigned char Digit;
+  unsigned char Digit = 0;
   unsigned char Byte;
 
   // Find out how many hex characters the string has.


### PR DESCRIPTION
The Mac mini 2018 has a couple device paths that are not of the expected format. This can cause gfxutil to hang. Of course, there are many places in the DevicePathToText library that may misbehave when given a badly formed path, but the point of these fixes is to handle only the cases that actually exist since getting Apple to fix the firmware won't happen and that wouldn't help those that have firmwares that give these paths.

These are the paths:
02010C00D041030A0000000001010600001E030A0500017FFF0400
02010C00D041030A0000000001010600001E030A0500027FFF0400
PciRoot(0x0)/Pci(0x1E,0x0)/VenMsg(,01)
PciRoot(0x0)/Pci(0x1E,0x0)/VenMsg(,02)

The device at 00:1E.0 is a 8086:a328 which is an Intel Cannon Lake PCH Serial IO UART Host Controller.

Changes:

edk2misc.c
- Implement new overrides for DevPathToTextVendor and ConvertFromTextVendor.
DevPathToTextVendor uses the old implementation if the size is large enough for an included UUID. Otherwise it assumes the UUID is missing and outputs something like this: VenMsg(,xx) where xx is the remaining bytes if any.
ConvertFromTextVendor is rewritten to accept an empty UUID for the first parameter.

edk2.overrides
- Enable new overrides for DevPathToTextVendor and ConvertFromTextVendor by renaming old implementations in edk2 with "Old" prefix and adding prototype for Old implementations.

gfxutil.xcscheme
- Added a couple sample arguments for testing this, one for path to text and another for text to path.